### PR TITLE
Fixed using the placebo implementation on MacOS

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -253,7 +253,7 @@ namespace stacktrace_tag {
 	struct backtrace;
 
 #	if   BACKWARD_HAS_UNWIND == 1
-	typedef unwind currnet;
+	typedef unwind current;
 #	elif BACKWARD_HAS_BACKTRACE == 1
 	typedef backtrace current;
 #	else


### PR DESCRIPTION
Hi,

I've fixed a minor overlooked link-time error in the empty Colorize class implementation for unknown systems. Also fixed an irrelevant typo.
