### PR TITLE
Fixed an unused parameter warning.

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -2112,7 +2112,7 @@ private:
 
 class SignalHandling {
 public:
-	SignalHandling(const std::vector<int>& signals = std::vector<int>()) { (void)signals; }
+	SignalHandling(const std::vector<int>& = std::vector<int>()) {}
 	bool init() { return false; }
 };
 


### PR DESCRIPTION
In SignalHandling constructor, the empty signal vector is never used,
which triggers unused parameter warnings at least on Clang 3.2.
