### PR TITLE
Fixing buffer overflow on signals array

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1879,7 +1879,7 @@ public:
 		SIGXCPU,
 		SIGXFSZ
 	};
-        return std::vector<int>(signals, signals + sizeof signals);
+        return std::vector<int>(signals, signals + sizeof signals / sizeof signals[0] );
    }
 
   SignalHandling(const std::vector<int>& signals = make_default_signals()):


### PR DESCRIPTION
Fixing a buffer overflow got with the clang address analyzer

==28362==ERROR: AddressSanitizer: global-buffer-overflow on address 0x0000004b29f8 at pc 0x45fe0c bp 0x7fffcb475390 sp 0x7fffcb474b50
READ of size 352 at 0x0000004b29f8 thread T0
    #0 0x45fe0b in memcpy (src/build/runUnitTests+0x45fe0b)
    #1 0x434e2a in int\* std::__copy_move<false, true, std::random_access_iterator_tag>::__copy_m<int>(int const_, int const_, int_) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl
_algobase.h:372
    #2 0x434e2a in int_ std::__copy_move_a<false, int const*, int*>(int const_, int const_, int_) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_algobase.h:389
    #3 0x434e2a in int_ std::__copy_move_a2<false, int const*, int*>(int const_, int const_, int_) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_algobase.h:426
    #4 0x434e2a in int_ std::copy<int const*, int*>(int const_, int const_, int_) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_algobase.h:458
    #5 0x434e2a in int_ std::__uninitialized_copy<true>::__uninit_copy<int const*, int*>(int const_, int const_, int_) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_uninitialize
d.h:93
    #6 0x434e2a in int_ std::uninitialized_copy<int const*, int*>(int const_, int const_, int_) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_uninitialized.h:115
    #7 0x434e2a in int_ std::__uninitialized_copy_a<int const*, int*, int>(int const_, int const_, int_, std::allocator<int>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_unin
itialized.h:258
    #8 0x434e2a in void std::vector<int, std::allocator<int> >::_M_range_initialize<int const_>(int const_, int const_, std::forward_iterator_tag) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c
++/4.8/bits/stl_vector.h:1204
    #9 0x434e2a in void std::vector<int, std::allocator<int> >::_M_initialize_dispatch<int const*>(int const_, int const_, std::__false_type) /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.
8/bits/stl_vector.h:1177
    #10 0x434e2a in vector<const int *, void> /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_vector.h:395
    #11 0x434e2a in backward::SignalHandling::make_default_signals() /home/ceolin/src/vcs/ioss/src/backward.hpp:2027
    #12 0x434e2a in __cxx_global_var_init src/backward.hpp:2030
    #13 0x434e2a in _GLOBAL__I_a src/tests/unittests.cpp:79
    #14 0x4a38cc in __libc_csu_init (src/build/runUnitTests+0x4a38cc)
    #15 0x7fb59b4c7d74 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21d74)
    #16 0x48ed6c in _start (src/build/runUnitTests+0x48ed6c)

0x0000004b29f8 is located 0 bytes to the right of global variable 'backward::SignalHandling::make_default_signals()::signals' from '/src/tests/unittests.cpp' (0x4b29a0) of size 88
SUMMARY: AddressSanitizer: global-buffer-overflow ??:0 memcpy
Shadow bytes around the buggy address:
  0x00008008e4e0: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x00008008e4f0: 00 01 f9 f9 f9 f9 f9 f9 01 f9 f9 f9 f9 f9 f9 f9
  0x00008008e500: 00 00 00 06 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
  0x00008008e510: 00 00 00 00 04 f9 f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x00008008e520: f9 f9 f9 f9 03 f9 f9 f9 f9 f9 f9 f9 00 00 00 02
=>0x00008008e530: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00[f9]
  0x00008008e540: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008008e550: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008008e560: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008008e570: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008008e580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==28362==ABORTING
