### PR TITLE
Include current source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endforeach()
 # TESTS
 ###############################################################################
 
-include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(test_main SHARED test/_test_main.cpp)
 


### PR DESCRIPTION
When including the project from a parent directory (add_subdirectory), backward.hpp is not found by the tests because we include CMAKE_SOURCE_DIR, which is the parent's source directory. Include CMAKE_CURRENT_SOURCE_DIR instead.
