### PR TITLE
Fix compilation warning under clang

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -364,8 +364,9 @@ public:
 	const T operator->() const { return _val; }
 
 	typedef typename rm_ptr<T>::type& ref_t;
+	typedef const typename rm_ptr<T>::type& const_ref_t;
 	ref_t operator*() { return *_val; }
-	const ref_t operator*() const { return *_val; }
+	const_ref_t operator*() const { return *_val; }
 	ref_t operator[](size_t idx) { return _val[idx]; }
 
 	// Watch out, we've got a badass over here


### PR DESCRIPTION
Clang complains about adding const to a reference type having no effect.
Fix this by adding and using a const_ref_t.
