### PR TITLE
Fix typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endmacro()
 map_definitions("STACK_DETAILS_" "BACKWARD_HAS_" BACKTRACE_SYMBOL DW BFD)
 map_definitions("STACK_WALKING_" "BACKWARD_HAS_" UNWIND BACKTRACE)
 
-foreach(def ${BACKWARD_DEFINITIONS})
+foreach(def ${backward_DEFINITIONS})
 	message(STATUS "${def}")
 endforeach()
 


### PR DESCRIPTION
Hopefully the last one: Should be backward_DEFINITIONS instead of BACKWARD_DEFINITIONS.
