### PR TITLE
Compilers with GLIBC < 2.10 don't have the psiginfo() function

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1945,7 +1945,9 @@ private:
 		printer.address = true;
 		printer.print(st, stderr);
 
+#if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L
 		psiginfo(info, 0);
+#endif
 
 		// try to forward the signal.
 		raise(info->si_signo);


### PR DESCRIPTION
At my company we have CentOS 5 (old, I know) and `backward.hpp` had a problem with the `psiginfo()` function.

I'm testing for the availability of it as stated in the linux man pages: http://linux.die.net/man/3/psiginfo