### PR TITLE
Add current List directory so that BackwardMacros.cmake correctly inc…

### DIFF
--- a/BackwardMacros.cmake
+++ b/BackwardMacros.cmake
@@ -111,7 +111,7 @@ foreach(def ${BACKWARD_DEFINITIONS})
 	message(STATUS "${def}")
 endforeach()
 
-LIST(APPEND BACKWARD_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+LIST(APPEND BACKWARD_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR})
 
 macro(add_backward target)
 	target_include_directories(${target} PRIVATE ${BACKWARD_INCLUDE_DIRS})


### PR DESCRIPTION
…ludes the directory

Without the change the include directory added to target properties would point to the targets source file instead of the source path of backward-cpp