### PR TITLE
Don't append definitions if already cached

### DIFF
--- a/BackwardMacros.cmake
+++ b/BackwardMacros.cmake
@@ -104,8 +104,10 @@ macro(map_definitions var_prefix define_prefix)
 	endforeach()
 endmacro()
 
-map_definitions("STACK_WALKING_" "BACKWARD_HAS_" UNWIND BACKTRACE)
-map_definitions("STACK_DETAILS_" "BACKWARD_HAS_" BACKTRACE_SYMBOL DW BFD)
+if (NOT BACKWARD_DEFINITIONS)
+	map_definitions("STACK_WALKING_" "BACKWARD_HAS_" UNWIND BACKTRACE)
+	map_definitions("STACK_DETAILS_" "BACKWARD_HAS_" BACKTRACE_SYMBOL DW BFD)
+endif()
 
 foreach(def ${BACKWARD_DEFINITIONS})
 	message(STATUS "${def}")


### PR DESCRIPTION
Hello,

Uppon modification of my CMakeLists my IDE (Clion) recall cmake on the same build dir, that uses the cache and append again the definitions to BACKWARD_DEFINITIONS.
It didn't generate build errors, but as the list of definition is dumped in BackwardMacros.cmake, I was curious.

Bye,
JB.
