### PR TITLE
Print to streams

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1679,10 +1679,14 @@ public:
 
 	void activate() {
 		_use_colors = true;
+		// in a colorful environment, reset at the beginning
+		set_color(Color::reset);
 	}
 
 	void activate_if_tty(std::FILE *desc) {
-		_use_colors = isatty(fileno(desc));
+		if (isatty(fileno(desc))) {
+			activate();
+		}
 	}
 
 	void set_color(Color::type ccode) {


### PR DESCRIPTION
Sometimes it is necessary to write the stack trace to
a stream (for example, an std::stringstream) instead
of a file (for example, if you want to output the stack trace
later, for a testing framework, or for a special kind of
exceptions with stack trace information).

This pull request makes the Printer (and Colorizer)
write to streams. For the Printer, backward-compatibility
is kept since all public print() methods use the
stream-based ones now.
For the Colorizer, this is a compatibility-breaking change.
