### PR TITLE
Make StackTraceImpl*::skip_n_firsts() setter public

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -496,6 +496,7 @@ public:
 	size_t load_here(size_t=0) { return 0; }
 	size_t load_from(void*, size_t=0) { return 0; }
 	unsigned thread_id() const { return 0; }
+	void skip_n_firsts(size_t) { }
 };
 
 #ifdef BACKWARD_SYSTEM_LINUX
@@ -508,6 +509,8 @@ public:
 		return _thread_id;
 	}
 
+	void skip_n_firsts(size_t n) { _skip = n; }
+
 protected:
 	void load_thread_info() {
 		_thread_id = syscall(SYS_gettid);
@@ -518,7 +521,6 @@ protected:
 		}
 	}
 
-	void skip_n_firsts(size_t n) { _skip = n; }
 	size_t skip_n_firsts() const { return _skip; }
 
 private:


### PR DESCRIPTION
When the stack trace is used directly (and not by a signal),
one may want to hide some of the first stack items because
they will always be the same calls.
