### PR TITLE
Don't use `and` for `&&`.

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1349,7 +1349,7 @@ private:
 		Dwarf_Addr low, high;
 
 		// continuous range
-		if (dwarf_hasattr(die, DW_AT_low_pc) and
+		if (dwarf_hasattr(die, DW_AT_low_pc) &&
 							dwarf_hasattr(die, DW_AT_high_pc)) {
 			if (dwarf_lowpc(die, &low) != 0) {
 				return false;


### PR DESCRIPTION
Operator names are not supported by MSVC out of the box. Using them breaks code that needs to build with MSVC and/or (thus) uses "-fno-operator-names". As a header-only library should pursue maximal
portability, this PR replaces the single usage of operator names with the more portable operator syntax.