### PR TITLE
Fix conanfile recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class BackwardCpp(ConanFile):
     generators = 'cmake'
 
     def cmake_option(self, option, prefix = ''):
-        return '-D{}{}={}'.format(prefix, option.upper(), self.options[option])
+        return '-D{}{}={}'.format(prefix, option.upper(), getattr(self.options, option))
 
     def build(self):
         cmake = CMake(self.settings)

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,13 +35,6 @@ class BackwardCpp(ConanFile):
         cmake = CMake(self.settings)
 
         options = ''
-        options += self.cmake_option('stack_walking_unwind')
-        options += self.cmake_option('stack_walking_backtrace')
-        options += self.cmake_option('stack_details_auto_detect')
-        options += self.cmake_option('stack_details_backtrace_symbol')
-        options += self.cmake_option('stack_details_dw')
-        options += self.cmake_option('stack_details_bfd')
-        options += self.cmake_option('shared', prefix = 'BACKWARD_')
 
         self.run('cmake {} {} {} -DBACKWARD_TESTS=OFF'.format(self.conanfile_directory, cmake.command_line, options))
         self.run('cmake --build . {}'.format(cmake.build_config))

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,6 +35,13 @@ class BackwardCpp(ConanFile):
         cmake = CMake(self.settings)
 
         options = ''
+        options += self.cmake_option('stack_walking_unwind')
+        options += self.cmake_option('stack_walking_backtrace')
+        options += self.cmake_option('stack_details_auto_detect')
+        options += self.cmake_option('stack_details_backtrace_symbol')
+        options += self.cmake_option('stack_details_dw')
+        options += self.cmake_option('stack_details_bfd')
+        options += self.cmake_option('shared', prefix = 'BACKWARD_')
 
         self.run('cmake {} {} {} -DBACKWARD_TESTS=OFF'.format(self.conanfile_directory, cmake.command_line, options))
         self.run('cmake --build . {}'.format(cmake.build_config))


### PR DESCRIPTION
It seems that the latest conan release changed the layout of the package options, so map syntax no longer works (Or it never had to be working and was my fault...).

I kept the revert commit in the history to make clear when I received and applied the conan.io feedback (Thanks @memsharded!).