### PR TITLE
Fix g++ 7.0.1 warnings

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1391,23 +1391,22 @@ private:
 					if (die_has_pc(die, pc)) {
 						return result;
 					}
-				default:
-					bool declaration = false;
-					Dwarf_Attribute attr_mem;
-					dwarf_formflag(dwarf_attr(die, DW_AT_declaration,
-								&attr_mem), &declaration);
-					if (!declaration) {
-						// let's be curious and look deeper in the tree,
-						// function are not necessarily at the first level, but
-						// might be nested inside a namespace, structure etc.
-						Dwarf_Die die_mem;
-						Dwarf_Die* indie = find_fundie_by_pc(die, pc, &die_mem);
-						if (indie) {
-							*result = die_mem;
-							return result;
-						}
-					}
 			};
+			bool declaration = false;
+			Dwarf_Attribute attr_mem;
+			dwarf_formflag(dwarf_attr(die, DW_AT_declaration,
+						&attr_mem), &declaration);
+			if (!declaration) {
+				// let's be curious and look deeper in the tree,
+				// function are not necessarily at the first level, but
+				// might be nested inside a namespace, structure etc.
+				Dwarf_Die die_mem;
+				Dwarf_Die* indie = find_fundie_by_pc(die, pc, &die_mem);
+				if (indie) {
+					*result = die_mem;
+					return result;
+				}
+			}
 		} while (dwarf_siblingof(die, result) == 0);
 		return 0;
 	}

--- a/backward.hpp
+++ b/backward.hpp
@@ -434,8 +434,8 @@ struct Trace {
 	Trace():
 		addr(0), idx(0) {}
 
-	explicit Trace(void* addr, size_t idx):
-		addr(addr), idx(idx) {}
+	explicit Trace(void* _addr, size_t _idx):
+		addr(_addr), idx(_idx) {}
 };
 
 struct ResolvedTrace: public Trace {
@@ -637,7 +637,7 @@ public:
 private:
 	struct callback {
 		StackTraceImpl& self;
-		callback(StackTraceImpl& self): self(self) {}
+		callback(StackTraceImpl& _self): self(_self) {}
 
 		void operator()(size_t idx, void* addr) {
 			self._stacktrace[idx] = addr;

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -37,8 +37,8 @@ namespace test {
 struct AssertFailedError: std::exception {
 	~AssertFailedError() throw() {}
 
-	AssertFailedError(const char* filename, int line, const char* errmsg):
-		basename(_basename(filename)), line(line), errmsg(errmsg) {}
+	AssertFailedError(const char* filename, int _line, const char* _errmsg):
+		basename(_basename(filename)), line(_line), errmsg(_errmsg) {}
 
 	const char* what() const throw() {
 		if (not _what.size()) {


### PR DESCRIPTION
The standard warnings of g++ 7.0.1 includes -Wimplicit-fallthrough.
The case of these warnings are fixed.

Enabling -Wshadow reveals further warnings that are fixed in this PR.