### PR TITLE
To pass sanitization, do not rely on underflow 0-1

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -72,6 +72,7 @@
 #include <streambuf>
 #include <string>
 #include <vector>
+#include <limits>
 
 #if defined(BACKWARD_SYSTEM_LINUX)
 
@@ -586,7 +587,12 @@ private:
 		uintptr_t ip = _Unwind_GetIPInfo(ctx, &ip_before_instruction);
 
 		if (!ip_before_instruction) {
-			ip -= 1;
+			// calculating 0-1 for unsigned, looks like a possible bug to sanitiziers, so let's do it explicitly:
+			if (ip==0) {
+				ip = std::numeric_limits<decltype(ip)>::max(); // set it to 0xffff... (as from casting 0-1)
+			} else {
+				ip -= 1; // else just normally decrement it (no overflow/underflow will happen)
+			}
 		}
 
 		if (_index >= 0) { // ignore first frame.

--- a/backward.hpp
+++ b/backward.hpp
@@ -589,7 +589,7 @@ private:
 		if (!ip_before_instruction) {
 			// calculating 0-1 for unsigned, looks like a possible bug to sanitiziers, so let's do it explicitly:
 			if (ip==0) {
-				ip = std::numeric_limits<decltype(ip)>::max(); // set it to 0xffff... (as from casting 0-1)
+				ip = std::numeric_limits<uintptr_t>::max(); // set it to 0xffff... (as from casting 0-1)
 			} else {
 				ip -= 1; // else just normally decrement it (no overflow/underflow will happen)
 			}


### PR DESCRIPTION
for ip==0, we sometimes calculate ip-=1.
ip is unsigned, so this is an underflow.

This is not strictly an UB, but more pedantic sanitizers
do catch this and report as possible error.

So why not instead just explicitly set value 0xffff...
(result of 0-1) and avoid this warnings.