### PR TITLE
Remove gcc-7 -Wshadow warning

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1674,7 +1674,7 @@ namespace ColorMode {
 
 class cfile_streambuf: public std::streambuf {
 public:
-	cfile_streambuf(FILE *sink): sink(sink) {}
+	cfile_streambuf(FILE *_sink): sink(_sink) {}
 	int_type underflow() { return traits_type::eof(); }
 	int_type overflow(int_type ch) {
 		if (traits_type::not_eof(ch) && fwrite(&ch, sizeof ch, 1, sink) == 1) {


### PR DESCRIPTION
While compiling with g++ 7, I get the following warning:

``` cpp
backward.hpp: In constructor ‘backward::cfile_streambuf::cfile_streambuf(FILE*)’:
backward.hpp:1677:29: warning: declaration of ‘sink’ shadows a member of ‘backward::cfile_streambuf’ [-Wshadow]
  cfile_streambuf(FILE *sink): sink(sink) {}
                             ^
backward.hpp:1701:8: note: shadowed declaration is here
  FILE *sink;
        ^~~~
```
And this PR removes that.