### PR TITLE
fix off-by-one when resolve goes up to ip==0 frame

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -752,7 +752,16 @@ public:
 		while (*funcname && *funcname != '(') {
 			funcname += 1;
 		}
-		trace.object_filename.assign(filename, funcname++);
+		trace.object_filename.assign(filename, funcname); // it is ok if funcname is the ending \0, then we select string till end
+
+		if ( ! (*funcname) ) { // we already hit end of string. This happens for the last address 0xffff for ip==0
+			trace.object_function = "(none)";
+			trace.source.function = "(none)";
+			return trace;
+		}
+
+		// else normal string, we are at the opening '(' now
+		funcname++;
 		char* funcname_end = funcname;
 		while (*funcname_end && *funcname_end != ')' && *funcname_end != '+') {
 			funcname_end += 1;

--- a/backward.hpp
+++ b/backward.hpp
@@ -755,7 +755,8 @@ public:
 		trace.object_filename.assign(filename, funcname); // ok even if funcname is the ending \0 (then we assign entire string)
 
 		if (*funcname) { // if it's not end of string (e.g. from last frame ip==0)
-			char* funcname_end = funcname + 1;
+			funcname += 1;
+			char* funcname_end = funcname;
 			while (*funcname_end && *funcname_end != ')' && *funcname_end != '+') {
 				funcname_end += 1;
 			}

--- a/backward.hpp
+++ b/backward.hpp
@@ -752,23 +752,17 @@ public:
 		while (*funcname && *funcname != '(') {
 			funcname += 1;
 		}
-		trace.object_filename.assign(filename, funcname); // it is ok if funcname is the ending \0, then we select string till end
+		trace.object_filename.assign(filename, funcname); // ok even if funcname is the ending \0 (then we assign entire string)
 
-		if ( ! (*funcname) ) { // we already hit end of string. This happens for the last address 0xffff for ip==0
-			trace.object_function = "(none)";
-			trace.source.function = "(none)";
-			return trace;
+		if (*funcname) { // if it's not end of string (e.g. from last frame ip==0)
+			char* funcname_end = funcname + 1;
+			while (*funcname_end && *funcname_end != ')' && *funcname_end != '+') {
+				funcname_end += 1;
+			}
+			*funcname_end = '\0';
+			trace.object_function = this->demangle(funcname);
+			trace.source.function = trace.object_function; // we cannot do better.
 		}
-
-		// else normal string, we are at the opening '(' now
-		funcname++;
-		char* funcname_end = funcname;
-		while (*funcname_end && *funcname_end != ')' && *funcname_end != '+') {
-			funcname_end += 1;
-		}
-		*funcname_end = '\0';
-		trace.object_function = this->demangle(funcname);
-		trace.source.function = trace.object_function; // we cannot do better.
 		return trace;
 	}
 


### PR DESCRIPTION
As discussed in comments of #63 , it can happen that we reach frame with ip==0, shown as "[0xffffffffffffffff]",
when using this library as documented and iterating entire backtrace up to "i<st.size()"

This situation causes a memory error (reading 1 position behind end of string), that was catched by valgrind.

This patch resolves it.