### PR TITLE
Add aarch64 support

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -2032,6 +2032,8 @@ private:
 		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.gregs[REG_EIP]);
 #elif defined(__arm__)
 		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.arm_pc);
+#elif defined(__aarch64__)
+		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.pc);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__)
 		error_addr = reinterpret_cast<void*>(uctx->uc_mcontext.regs->nip);
 #else

--- a/test/suicide.cpp
+++ b/test/suicide.cpp
@@ -64,6 +64,8 @@ TEST_ABORT (calling_abort)
 	abort_abort_I_repeat_abort_abort();
 }
 
+// aarch64 does not trap Division by zero
+#ifndef __aarch64__
 volatile int zero = 0;
 
 int divide_by_zero()
@@ -78,6 +80,7 @@ TEST_DIVZERO (divide_by_zero)
 	int v = divide_by_zero();
 	std::cout << "v=" << v << std::endl;
 }
+#endif
 
 int bye_bye_stack(int i) {
 	return bye_bye_stack(i + 1) + bye_bye_stack(i * 2);


### PR DESCRIPTION
*Read the pc as specified for aarch64 processors.
*Disable division by zero tests, since aarch64 does not trap these and
 therefore does not generate SIGFPEs there.
*All other tests succeed.