### PR TITLE
backward-cpp: Make sure to properly link against bfd.a

### DIFF
--- a/BackwardConfig.cmake
+++ b/BackwardConfig.cmake
@@ -78,6 +78,13 @@ if (${STACK_DETAILS_AUTO_DETECT})
 	elseif(LIBBFD_FOUND)
 		LIST(APPEND _BACKWARD_INCLUDE_DIRS ${LIBBFD_INCLUDE_DIRS})
 		LIST(APPEND BACKWARD_LIBRARIES ${LIBBFD_LIBRARIES})
+
+		# If we attempt to link against static bfd, make sure to link its dependencies, too
+		get_filename_component(bfd_lib_ext "${LIBBFD_LIBRARY}" EXT)
+		if (bfd_lib_ext STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+			list(APPEND BACKWARD_LIBRARIES iberty z)
+		endif()
+
 		set(STACK_DETAILS_DW FALSE)
 		set(STACK_DETAILS_BFD TRUE)
 		set(STACK_DETAILS_BACKTRACE_SYMBOL FALSE)


### PR DESCRIPTION
On some distributions, libbfd is only available as static library. E.g.
on OpenSuse Leap 42.2, there are these two files:
  libbfd.a
  libbfd-2.28-system.so

backward-cpp, when attempting to link to bfd, will select the static
library and fail b/c there are undefined references to symbols from
libiberty/libz:
```
/usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../lib64/libbfd.a(elflink.o):
In function `elf_link_add_object_symbols':
/home/abuild/rpmbuild/BUILD/binutils-2.26.1/build-dir/bfd/../../bfd/elflink.c:4733:
undefined reference to `objalloc_free_block'
/home/abuild/rpmbuild/BUILD/binutils-2.26.1/build-dir/bfd/../../bfd/elflink.c:5027:
undefined reference to `_sch_istable'
...
```

After this patch we also link against the direct dependencies of libbfd.a, namely libiberty and libz

Also see: https://github.com/KDAB/GammaRay/issues/386