### PR TITLE
Fixes

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -432,7 +432,7 @@ struct demangler:
 
 struct Trace {
 	void*    addr;
-	unsigned idx;
+	size_t   idx;
 
 	Trace():
 		addr(0), idx(0) {}
@@ -498,7 +498,7 @@ public:
 	Trace operator[](size_t) { return Trace(); }
 	size_t load_here(size_t=0) { return 0; }
 	size_t load_from(void*, size_t=0) { return 0; }
-	unsigned thread_id() const { return 0; }
+	size_t thread_id() const { return 0; }
 	void skip_n_firsts(size_t) { }
 };
 
@@ -508,7 +508,7 @@ class StackTraceLinuxImplBase {
 public:
 	StackTraceLinuxImplBase(): _thread_id(0), _skip(0) {}
 
-	unsigned thread_id() const {
+	size_t thread_id() const {
 		return _thread_id;
 	}
 
@@ -516,7 +516,7 @@ public:
 
 protected:
 	void load_thread_info() {
-		_thread_id = syscall(SYS_gettid);
+		_thread_id = (size_t)syscall(SYS_gettid);
 		if (_thread_id == (size_t) getpid()) {
 			// If the thread is the main one, let's hide that.
 			// I like to keep little secret sometimes.
@@ -742,7 +742,7 @@ public:
 				return;
 			}
 			_symbols.reset(
-					backtrace_symbols(st.begin(), st.size())
+					backtrace_symbols(st.begin(), (int)st.size())
 					);
 		}
 
@@ -1345,8 +1345,8 @@ private:
 								&attr_mem), &line);
 					dwarf_formudata(dwarf_attr(die, DW_AT_call_column,
 								&attr_mem), &col);
-					sloc.line = line;
-					sloc.col = col;
+					sloc.line = (unsigned)line;
+					sloc.col = (unsigned)col;
 
 					trace.inliners.push_back(sloc);
 					break;
@@ -1856,7 +1856,7 @@ private:
 			}
 		}
 
-	void print_header(std::ostream& os, unsigned thread_id) {
+	void print_header(std::ostream& os, size_t thread_id) {
 		os << "Stack trace (most recent call last)";
 		if (thread_id) {
 			os << " in thread " << thread_id;

--- a/backward.hpp
+++ b/backward.hpp
@@ -1975,7 +1975,6 @@ public:
 		SIGSEGV,    // Invalid memory reference
 		SIGSYS,     // Bad argument to routine (SVr4)
 		SIGTRAP,    // Trace/breakpoint trap
-		SIGUNUSED,  // Synonymous with SIGSYS
 		SIGXCPU,    // CPU time limit exceeded (4.2BSD)
 		SIGXFSZ,    // File size limit exceeded (4.2BSD)
 	};


### PR DESCRIPTION
Fix #71 

```
In file included from backward.cpp:26:0:
backward.hpp: In static member function ‘static std::vector<int> backward::SignalHandling::make_default_signals()’:
backward.hpp:1978:3: error: ‘SIGUNUSED’ was not declared in this scope
   SIGUNUSED,  // Synonymous with SIGSYS
   ^~~~~~~~~
backward.hpp:1978:3: note: suggested alternative: ‘SI_USER’
   SIGUNUSED,  // Synonymous with SIGSYS
   ^~~~~~~~~
   SI_USER
```

And also some conversion warnings

```
In file included from backward/backward.cpp:26:0:
backward.hpp: In constructor ‘backward::Trace::Trace(void*, size_t)’:
backward.hpp:444:24: error: conversion to ‘unsigned int’ from ‘size_t {aka long unsigned int}’ may alter its value [-Werror=conversion]
   addr(_addr), idx(_idx) {}
                        ^
backward.hpp: In member function ‘unsigned int backward::StackTraceLinuxImplBase::thread_id() const’:
backward.hpp:515:10: error: conversion to ‘unsigned int’ from ‘size_t {aka long unsigned int}’ may alter its value [-Werror=conversion]
   return _thread_id;
          ^
backward.hpp: In instantiation of ‘void backward::TraceResolverLinuxImpl<backward::trace_resolver_tag::backtrace_symbol>::load_stacktrace(ST&) [with ST = backward::StackTrace]’:
backward.hpp:1848:4:   required from ‘void backward::Printer::print_stacktrace(ST&, std::ostream&, backward::Colorize&) [with ST = backward::StackTrace; std::ostream = std::basic_ostream<char>]’
backward.hpp:1819:4:   required from ‘std::ostream& backward::Printer::print(ST&, std::ostream&) [with ST = backward::StackTrace; std::ostream = std::basic_ostream<char>]’
backward.hpp:2059:23:   required from here
backward.hpp:748:45: error: conversion to ‘int’ from ‘size_t {aka long unsigned int}’ may alter its value [-Werror=conversion]
      backtrace_symbols(st.begin(), st.size())
In file included from ../backward.cpp:26:0:
backward.hpp: In member function ‘void backward::TraceResolverLinuxImpl<backward::trace_resolver_tag::libdw>::inliners_search_cb::operator()(Dwarf_Die*)’:
backward.hpp:1348:18: error: conversion to ‘unsigned int’ from ‘Dwarf_Word {aka long unsigned int}’ may alter its value [-Werror=conversion]
      sloc.line = line;
                  ^~~~
backward.hpp:1349:17: error: conversion to ‘unsigned int’ from ‘Dwarf_Word {aka long unsigned int}’ may alter its value [-Werror=conversion]
      sloc.col = col;
```


With clang (there are also other warnings)
```
In file included from backward.cpp:26:
backward.hpp:519:16: error: implicit conversion changes signedness: 'long' to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
                _thread_id = syscall(SYS_gettid);
                           ~ ^~~~~~~~~~~~~~~~~~~
```
