### PR TITLE
Fix compilation on gcc-4.1

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1590,7 +1590,7 @@ public:
 		swap(from); return *this;
 	}
 #else
-	explicit SourceFile(const SourceFile& from) {
+	SourceFile(const SourceFile& from) {
 		// some sort of poor man's move semantic.
 		swap(const_cast<SourceFile&>(from));
 	}


### PR DESCRIPTION
Some old but long-lasting system (like those installed on supercomputers) use pretty old compilers. So make backward work on gcc-4.1 is useful. This PR fixes it. It is tested on docker uilianries/conangcc41 and both the compilation and the stacktrace printing works.