### PR TITLE
Allow running sighandler logic as part of a cleanup chain

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -2017,14 +2017,7 @@ public:
 
 	bool loaded() const { return _loaded; }
 
-private:
-	details::handle<char*> _stack_content;
-	bool                   _loaded;
-
-#ifdef __GNUC__
-	__attribute__((noreturn))
-#endif
-	static void sig_handler(int, siginfo_t* info, void* _ctx) {
+	static void handleSignal(int, siginfo_t* info, void* _ctx) {
 		ucontext_t *uctx = (ucontext_t*) _ctx;
 
 		StackTrace st;
@@ -2055,6 +2048,17 @@ private:
 #if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L
 		psiginfo(info, 0);
 #endif
+	}
+
+private:
+	details::handle<char*> _stack_content;
+	bool                   _loaded;
+
+#ifdef __GNUC__
+	__attribute__((noreturn))
+#endif
+	static void sig_handler(int signo, siginfo_t* info, void* _ctx) {
+		handleSignal(signo, info, _ctx);
 
 		// try to forward the signal.
 		raise(info->si_signo);


### PR DESCRIPTION
In our code, we need to take certain cleanup actions
after receiving a SIGSEGV. This makes it difficult to
integrate with backward, as our custom sighandler is overriden.

A simple solution is to have backward-cpp expose the
core sighandling logic as a public function, which
we can simply call from within our code. This is not
currently possible since sig_handler is private, and
additionally raises the signal again at the end.

This pull request makes the above possible. The alternative
is to copy handleSignal into our own code, which is just ugly.