### PR TITLE
Update conan recipes to use the latest recipe APIs. Fixes #90

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
 
 script:
   - valgrind ctest .. --verbose
-  - cd ${TRAVIS_BUILD_DIR} && conan test_package --build=outdated
+  - cd ${TRAVIS_BUILD_DIR} && conan create Manu343726/testing --build=outdated

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,23 +28,11 @@ class BackwardCpp(ConanFile):
     exports = 'backward.cpp', 'backward.hpp', 'test/*', 'CMakeLists.txt', 'BackwardConfig.cmake'
     generators = 'cmake'
 
-    def cmake_option(self, option, prefix = ''):
-        return '-D{}{}={}'.format(prefix, option.upper(), getattr(self.options, option))
-
     def build(self):
-        cmake = CMake(self.settings)
+        cmake = CMake(self)
 
-        options = ''
-        options += self.cmake_option('stack_walking_unwind')
-        options += self.cmake_option('stack_walking_backtrace')
-        options += self.cmake_option('stack_details_auto_detect')
-        options += self.cmake_option('stack_details_backtrace_symbol')
-        options += self.cmake_option('stack_details_dw')
-        options += self.cmake_option('stack_details_bfd')
-        options += self.cmake_option('shared', prefix = 'BACKWARD_')
-
-        self.run('cmake {} {} {} -DBACKWARD_TESTS=OFF'.format(self.conanfile_directory, cmake.command_line, options))
-        self.run('cmake --build . {}'.format(cmake.build_config))
+        cmake.configure(defs={'BACKWARD_' + name.upper(): value for name, value in self.options.values.as_list()})
+        cmake.build()
 
     def package(self):
         self.copy('backward.hpp', os.path.join('include', 'backward'))

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,10 +2,7 @@ project(backward-package-test)
 cmake_minimum_required(VERSION 2.8)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-include(${CONAN_CMAKE-UTILS_ROOT}/conan.cmake)
-conan_basic_setup()
-
-add_conan_library(backward)
+conan_basic_setup(TARGETS)
 
 add_executable(example main.cpp)
-target_link_libraries(example PRIVATE backward-conan)
+target_link_libraries(example PRIVATE ${CONAN_TARGETS})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -3,13 +3,12 @@ import os
 
 class TestBackward(ConanFile):
     settings = 'os', 'compiler', 'build_type', 'arch'
-    requires = 'cmake-utils/0.0.0@Manu343726/testing', 'backward/1.3.0@Manu343726/testing'
     generators = 'cmake'
 
     def build(self):
-        cmake = CMake(self.settings)
-        self.run('cmake {} {}'.format(self.conanfile_directory, cmake.command_line))
-        self.run('cmake --build . {}'.format(cmake.build_config))
+        cmake = CMake(self)
+        cmake.configure(defs={'CMAKE_VERBOSE_MAKEFILE': 'ON'})
+        cmake.build()
 
     def test(self):
         self.run(os.path.join('.', 'bin', 'example'))


### PR DESCRIPTION
See #90.

Basically, the conan recipes and the build commands used by the CI were outdated (the conan team seem to have been working so hard these last months, releasing like rabbits :P)