### PR TITLE
Remove warning about unused variable 'info"

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -2241,6 +2241,8 @@ public:
 
 #if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L
 		psiginfo(info, 0);
+#else
+		(void)info;
 #endif
 	}
 


### PR DESCRIPTION
On some platforms we got a warning about 'info' not being used because the `#if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L` was not true. Can't remember which platform right now but this patch addressed it.