### PR TITLE
add check for __linux__

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -56,7 +56,7 @@
 #elif defined(BACKWARD_SYSTEM_DARWIN)
 #elif defined(BACKWARD_SYSTEM_UNKNOWN)
 #else
-#	if defined(__linux)
+#	if defined(__linux) || defined(__linux__)
 #		define BACKWARD_SYSTEM_LINUX
 #	elif defined(__APPLE__)
 #		define BACKWARD_SYSTEM_DARWIN


### PR DESCRIPTION
Some compiler flags and/or compilers will set this instead. There are
undoubtedly others but I know this fixes my problem.

The flag that I'm currently seeing alter this is `-std=c++0x`.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>