### PR TITLE
Make cmake append libs dwarf and elf

### DIFF
--- a/BackwardConfig.cmake
+++ b/BackwardConfig.cmake
@@ -133,7 +133,7 @@ else()
 	endif()
 
 	if (STACK_DETAILS_DWARF)
-		LIST(APPEND BACKWARD_LIBRARIES dwarf elf)
+		LIST(APPEND _BACKWARD_LIBRARIES dwarf elf)
 	endif()
 endif()
 


### PR DESCRIPTION
Without this they are not correctly included in BACKWARD_LIBRARIES even when they are found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bombela/backward-cpp/110)
<!-- Reviewable:end -->
