### PR TITLE
Find libdwarf.h on debian

### DIFF
--- a/BackwardConfig.cmake
+++ b/BackwardConfig.cmake
@@ -72,7 +72,7 @@ if (${STACK_DETAILS_AUTO_DETECT})
 		LIBDL_INCLUDE_DIR LIBDL_LIBRARY)
 
 	# find libdwarf
-	find_path(LIBDWARF_INCLUDE_DIR NAMES "libdwarf.h")
+	find_path(LIBDWARF_INCLUDE_DIR NAMES "libdwarf.h" PATH_SUFFIXES libdwarf)
 	find_path(LIBELF_INCLUDE_DIR NAMES "libelf.h")
 	find_path(LIBDL_INCLUDE_DIR NAMES "dlfcn.h")
 	find_library(LIBDWARF_LIBRARY dwarf)


### PR DESCRIPTION
Debian installs `libdwarf.h` at `/usr/include/libdwarf/`. This change enables cmake finding this header on [debian](https://packages.debian.org/stretch/amd64/libdwarf-dev/filelist).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bombela/backward-cpp/111)
<!-- Reviewable:end -->
