### PR TITLE
Export each definition individually

### DIFF
--- a/BackwardConfig.cmake
+++ b/BackwardConfig.cmake
@@ -180,6 +180,16 @@ set(BACKWARD_DEFINITIONS ${_BACKWARD_DEFINITIONS} CACHE INTERNAL "BACKWARD_DEFIN
 set(BACKWARD_LIBRARIES ${_BACKWARD_LIBRARIES} CACHE INTERNAL "BACKWARD_LIBRARIES")
 mark_as_advanced(BACKWARD_INCLUDE_DIRS BACKWARD_DEFINITIONS BACKWARD_LIBRARIES)
 
+# Expand each definition in BACKWARD_DEFINITIONS to its own cmake var and export
+# to outer scope
+foreach(var ${BACKWARD_DEFINITIONS})
+  string(REPLACE "=" ";" var_as_list ${var})
+  list(GET var_as_list 0 var_name)
+  list(GET var_as_list 1 var_value)
+  set(${var_name} ${var_value})
+  mark_as_advanced(${var_name})
+endforeach()
+
 if (NOT TARGET Backward::Backward)
 	add_library(Backward::Backward INTERFACE IMPORTED)
 	set_target_properties(Backward::Backward PROPERTIES


### PR DESCRIPTION
This allows using each definition (resulting from `BackwardConfig.cmake`) separately, e.g., in conjunction with cmake's `configure_file()` command and thus can be defined in a cmake-generated source file before a build.

Example:

`Config.h.in`
```cmake
 #cmakedefine01 BACKWARD_HAS_UNWIND
 #cmakedefine01 BACKWARD_HAS_BACKTRACE
 #cmakedefine01 BACKWARD_HAS_BACKTRACE_SYMBOL
 #cmakedefine01 BACKWARD_HAS_DW
 #cmakedefine01 BACKWARD_HAS_BFD
 #cmakedefine01 BACKWARD_HAS_DWARF
```
`CMakeLists.txt`:
```cmake
 include(BackwardConfig)
 configure_file( "${PROJECT_SOURCE_DIR}/Config.h.in"
                 "${PROJECT_BINARY_DIR}/Config.h" )
```
`SomeProjectFile.C`:
```cpp
 #include "Config.h"      // generated by cmake based on Config.h.in
 #include "backward.hpp"  // backward-cpp now configured based on BackwardConfig.cmake

 using namespace backward;
 StackTrace st; st.load_here(32);
 Printer p; p.print(st);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bombela/backward-cpp/112)
<!-- Reviewable:end -->
