### PR TITLE
Code optimizations

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -2328,7 +2328,8 @@ private:
 						&ranges_count, &byte_count, &error) == DW_DLV_OK) {
 					has_ranges = ranges_count != 0;
 					for (int i = 0; i < ranges_count; i++) {
-						if (pc >= ranges[i].dwr_addr1 + low_pc &&
+						if (ranges[i].dwr_addr1 != 0 &&
+							pc >= ranges[i].dwr_addr1 + low_pc &&
 							pc < ranges[i].dwr_addr2 + low_pc) {
 							result = true;
 							break;

--- a/backward.hpp
+++ b/backward.hpp
@@ -1899,7 +1899,7 @@ private:
 	}
 
 	dwarf_fileobject& load_object_with_dwarf(
-			const std::string filename_object) {
+			const std::string& filename_object) {
 
 		if (!_dwarf_loaded) {
 			// Set the ELF library operating version

--- a/backward.hpp
+++ b/backward.hpp
@@ -2429,8 +2429,9 @@ private:
 			while (dwarf_next_cu_header_d(dwarf, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 					&next_cu_header, 0, &error) == DW_DLV_OK) {
 				// Reset the cu header state. Unfortunately, libdwarf's
-				// next_cu_header API keeps its own iterator per Dwarf_Debug that
-				// can't be reset. We need to keep fetching elements until the end.
+				// next_cu_header API keeps its own iterator per Dwarf_Debug
+				// that can't be reset. We need to keep fetching elements until
+				// the end.
 			}
 		} else {
 			// If we couldn't resolve the type just print out the signature
@@ -2438,7 +2439,8 @@ private:
 			string_stream << "<0x" <<
 					std::hex << std::setfill('0');
 			for (int i = 0; i < 8; ++i) {
-				string_stream << std::setw(2) << std::hex << (int)(unsigned char)(signature.signature[i]);
+				string_stream << std::setw(2) << std::hex
+						<< (int)(unsigned char)(signature.signature[i]);
 			}
 			string_stream << ">";
 			result = string_stream.str();
@@ -2562,7 +2564,8 @@ private:
 
 		context.is_const = next_type_is_const;
 
-		Dwarf_Die ref = get_referenced_die(fobj.dwarf_handle.get(), die, DW_AT_type, true);
+		Dwarf_Die ref = get_referenced_die(
+				fobj.dwarf_handle.get(), die, DW_AT_type, true);
 		if (ref) {
 			set_parameter_string(fobj, ref, context);
 			dwarf_dealloc(fobj.dwarf_handle.get(), ref, DW_DLA_DIE);


### PR DESCRIPTION
Improve how CU DIEs are iterated by only processing those whose tag is DW_TAG_compile_unit. Reset (ie, advance to the end) libdwarf's CU iterator only if we found a CU as, if not, we will be already be at the end.