### PR TITLE
Add missing ref qualifier

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -491,7 +491,7 @@ public:
 		// bools without throwing... It's a lost cause anyway!
 	}
 
-	T operator->() { return _val; }
+	T& operator->() { return _val; }
 	const T& operator->() const { return _val; }
 
 	typedef typename rm_ptr<T>::type& ref_t;

--- a/backward.hpp
+++ b/backward.hpp
@@ -492,7 +492,7 @@ public:
 	}
 
 	T operator->() { return _val; }
-	const T operator->() const { return _val; }
+	const T& operator->() const { return _val; }
 
 	typedef typename rm_ptr<T>::type& ref_t;
 	typedef const typename rm_ptr<T>::type& const_ref_t;


### PR DESCRIPTION
Returning a `const T` as opposed to `const T&` serves little purpose and 
is most likely not what the writer intended.
This was called out by clang-tidy.