### PR TITLE
Partial file_handle fix

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1926,7 +1926,7 @@ private:
 
 		dwarf_file_t file_handle;
 		file_handle.reset(open(filename_object.c_str(), O_RDONLY));
-		if (file_handle < 0) {
+		if (file_handle.get() < 0) {
 			return r;
 		}
 


### PR DESCRIPTION
In

`file_handle.reset(open(filename_object.c_str(), O_RDONLY));` 

`open` returns 0 only if we open `stdout`. That means in `reset` we always creating empty handler in this line: 

`explicit handle(T val): _val(val), _empty(false) { if(!_val) _empty = true; }`

and that means when we convert to pointer in

```
operator const dummy*() const {
		if (_empty) {
			return nullptr;
		}
		return reinterpret_cast<const dummy*>(_val);
}
```

we always return 0.

but since in lines

```
if (file_handle < 0) {
			return r;
}
```

`0 < 0 == true` code never returns, even when open failed. Also, since file_handle is empty, file never closes:


```
~handle() {
	if (!_empty) {
		Deleter()(_val);
	}
}
```

But to check this API should be changed.  Simplest change I can think of is adding lambda to check emptiness:

```
explicit handle(T val, std::function<bool(T const &val)> is_empty): _val(val), _empty(false) { 
    _empty = is_empty(val);
}

//...

void reset(T new_val, std::function<bool(T const &val)> is_empty) {
		handle tmp(new_val, is_empty);
		swap(tmp);
}

//...

file_handle.reset(open(filename_object.c_str(), O_RDONLY), [](int const &v){return v<0;});
```

Alternatively, template can be specified differently for `int`. That's not up to me anyway.