### PR TITLE
Improve portability to non-glibc Linux systems

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1686,7 +1686,7 @@ public:
 
 		Dl_info symbol_info;
 		int dladdr_result = 0;
-#ifndef __ANDROID__
+#if defined(__GLIBC__)
 		link_map *link_map;
 		// We request the link map so we can get information about offsets
 		dladdr_result = dladdr1(trace.addr, &symbol_info,
@@ -1742,7 +1742,7 @@ public:
 			return trace; // sad, we couldn't load the object :(
 		}
 
-#ifndef __ANDROID__
+#if defined(__GLIBC__)
 		// Convert the address to a module relative one by looking at
 		// the module's loading address in the link map
 		Dwarf_Addr address = reinterpret_cast<uintptr_t>(trace.addr) -

--- a/backward.hpp
+++ b/backward.hpp
@@ -611,7 +611,7 @@ template <typename TAG>
 class StackTraceImpl {
 public:
 	size_t size() const { return 0; }
-	Trace operator[](size_t) { return Trace(); }
+	Trace operator[](size_t) const { return Trace(); }
 	size_t load_here(size_t=0) { return 0; }
 	size_t load_from(void*, size_t=0) { return 0; }
 	size_t thread_id() const { return 0; }

--- a/test/_test_main.cpp
+++ b/test/_test_main.cpp
@@ -24,14 +24,20 @@
 #include "test.hpp"
 #include <cstdio>
 #include <cstdlib>
-#ifndef __APPLE__
-#include <error.h>
-#endif
 #include <unistd.h>
 #include <sys/wait.h>
 
-#ifdef __APPLE__
+#if defined(__has_include) && __has_include(<error.h>)
+#include <error.h>
+#else
 #include <stdarg.h>
+
+#ifndef __APPLE__
+// N.B.  getprogname() is an Apple/BSD-ism.
+// program_invocation_name is a GLIBC-ism, but it's also
+//  supported by libmusl.
+#define getprogname() program_invocation_name
+#endif
 
 void error(int status, int errnum, const char *format, ...) {
 	fflush(stdout);


### PR DESCRIPTION
Linux is not synonymous with glibc.  Alpine linux (among others) uses
libmusl as the standard C library.  Alpine/libmusl doesn't have
backtrace, dladdr1, execinfo.h or error.h.  It does have libunwind
and program_invocation_name and libdwarf and libelf are available as
packages.

This patch makes backward-cpp work on Alpine linux (and hopefully
others that rely on libmusl).

This patch makes dladdr1 dependent on the __GLIBC__ pp-symbol
(rather than __ANDROID__).

It uses __has_include (protected by a defined()) rather than __APPLE__
to decide whether to include <error.h> in _test_main.cpp.