### PR TITLE
DW_AT_call_file is an unsigned value

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1555,9 +1555,9 @@ private:
 
   static const char *die_call_file(Dwarf_Die *die) {
     Dwarf_Attribute attr_mem;
-    Dwarf_Sword file_idx = 0;
+    Dwarf_Word file_idx = 0;
 
-    dwarf_formsdata(dwarf_attr(die, DW_AT_call_file, &attr_mem), &file_idx);
+    dwarf_formudata(dwarf_attr(die, DW_AT_call_file, &attr_mem), &file_idx);
 
     if (file_idx == 0) {
       return 0;
@@ -2847,12 +2847,12 @@ private:
                                    Dwarf_Die cu_die) {
     Dwarf_Attribute attr_mem;
     Dwarf_Error error = DW_DLE_NE;
-    Dwarf_Signed file_index;
+    Dwarf_Unsigned file_index;
 
     std::string file;
 
     if (dwarf_attr(die, DW_AT_call_file, &attr_mem, &error) == DW_DLV_OK) {
-      if (dwarf_formsdata(attr_mem, &file_index, &error) != DW_DLV_OK) {
+      if (dwarf_formudata(attr_mem, &file_index, &error) != DW_DLV_OK) {
         file_index = 0;
       }
       dwarf_dealloc(dwarf, attr_mem, DW_DLA_ATTR);


### PR DESCRIPTION
According to the spec (http://www.dwarfstd.org/doc/DWARF4.pdf, section 2.14) the DW_AT_call_file attribute (like DW_AT_call_line and DW_AT_call_column) is an Unsigned Integer constant and not a Signed Integer. I was getting crashes in debug symbols created by gcc 4.9.0 for ARM because it was incorrectly getting a very high number that, in backward, was being interpreted as a negative value.