### PR TITLE
Add mips support

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -3570,6 +3570,8 @@ public:
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
+#elif defined(__mips__)
+    error_addr = reinterpret_cast<void *>(reinterpret_cast<struct sigcontext*>(&uctx->uc_mcontext)->sc_pc);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) ||        \
     defined(__POWERPC__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.regs->nip);

--- a/test/suicide.cpp
+++ b/test/suicide.cpp
@@ -54,8 +54,8 @@ void abort_abort_I_repeat_abort_abort() {
 
 TEST_ABORT(calling_abort) { abort_abort_I_repeat_abort_abort(); }
 
-// aarch64 does not trap Division by zero
-#ifndef __aarch64__
+// aarch64 and mips does not trap Division by zero
+#if !defined(__aarch64__) || !defined(__mips__)
 volatile int zero = 0;
 
 int divide_by_zero() {


### PR DESCRIPTION
MIPS didn't export regs at mcontext_t so we need to cast it as sigcontext.
All test passed on my mips64el machine.