### PR TITLE
Allow specifying list of source file search paths in environment var

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -397,11 +397,15 @@ template <typename T> T &move(T &v) { return v; }
 } // namespace backward
 #endif // BACKWARD_ATLEAST_CXX11
 
+namespace backward {
+namespace details {
 #if defined(BACKWARD_SYSTEM_WINDOWS)
 const char kBackwardPathDelimiter[] = ";";
 #else
 const char kBackwardPathDelimiter[] = ":";
 #endif
+} // namespace details
+} // namespace backward
 
 namespace backward {
 

--- a/backward.hpp
+++ b/backward.hpp
@@ -398,9 +398,9 @@ template <typename T> T &move(T &v) { return v; }
 #endif // BACKWARD_ATLEAST_CXX11
 
 #if defined(BACKWARD_SYSTEM_WINDOWS)
-#define BACKWARD_PATH_DELIMITER ";"
+const char kBackwardPathDelimiter[] = ";";
 #else
-#define BACKWARD_PATH_DELIMITER ":"
+const char kBackwardPathDelimiter[] = ":";
 #endif
 
 namespace backward {
@@ -603,12 +603,12 @@ struct demangler : public demangler_impl<system_tag::current_tag> {};
 //   etc.
 inline std::vector<std::string> split_source_prefixes(const std::string &s) {
   std::vector<std::string> out;
-  std::string delimiter = BACKWARD_PATH_DELIMITER;
   size_t last = 0;
   size_t next = 0;
-  while ((next = s.find(delimiter, last)) != std::string::npos) {
+  size_t delimiter_size = sizeof(kBackwardPathDelimiter)-1;
+  while ((next = s.find(kBackwardPathDelimiter, last)) != std::string::npos) {
     out.push_back(s.substr(last, next-last));
-    last = next + delimiter.size();
+    last = next + delimiter_size;
   }
   if (last <= s.length()) {
     out.push_back(s.substr(last));


### PR DESCRIPTION
This is useful for binaries (using backward-cpp) that are built with
relative source file paths.  In such a situation, backward-cpp will
generally not be able to locate the source files.  This change allows
the user to specify a delimited list of search paths in the following
environment variable:

```
BACKWARD_CXX_SOURCE_PREFIXES
```

The paths are separated by semicolons on Windows and colons otherwise.
When the environment variable is set, those search paths will be tried
first.  If they do not yield any valid files then backward-cpp will
fall back to current behavior.

Fixes #153 