### PR TITLE
fix bad pointer comparison in libdwarf backend

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1989,7 +1989,7 @@ private:
 
     dwarf_file_t file_handle;
     file_handle.reset(open(filename_object.c_str(), O_RDONLY));
-    if (file_handle < 0) {
+    if (file_handle.get() < 0) {
       return r;
     }
 


### PR DESCRIPTION
I can't even compile backward-cpp without this fix.