### PR TITLE
Call `std::getline` with an lvalue `std::ifstream` rather than an rvalue

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1028,7 +1028,8 @@ private:
 
   static std::string get_argv0() {
     std::string argv0;
-    std::getline(std::ifstream("/proc/self/cmdline"), argv0, '\0');
+    std::ifstream ifs("/proc/self/cmdline");
+    std::getline(ifs, argv0, '\0');
     return argv0;
   }
 


### PR DESCRIPTION
Older libstdc++ versions (e.g. 4.8.2) don't have the rvalue overload of `std::getline`. This fixes this error when compiled with libstdc++ 4.8.2:

```
ext/backward-cpp/backward.hpp: In static member function 'static std::string backward::TraceResolverLinuxBase::get_argv0()':
ext/backward-cpp/backward.hpp:1031:66: error: no matching function for call to 'getline(std::ifstream, std::string&, char)'
     std::getline(std::ifstream("/proc/self/cmdline"), argv0, '\0');
                                                                  ^
ext/backward-cpp/backward.hpp:1031:66: note: candidates are:
/usr/include/c++/4.8/bits/basic_string.h:2799:5: note: std::basic_istream<_CharT, _Traits>& std::getline(std::basic_istream<_CharT, _Traits>&, std::basic_string<_CharT, _Traits, _Alloc>&, _CharT) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]
     getline(basic_istream<char>& __in, basic_string<char>& __str,
     ^
/usr/include/c++/4.8/bits/basic_string.h:2799:5: note:   no known conversion for argument 1 from 'std::ifstream {aka std::basic_ifstream<char>}' to 'std::basic_istream<char>&'
```

This was a bug I introduced in #81, so it's somewhat ironic that I'm (apparently) the first person to be affected by it...