### PR TITLE
leak due to _empty set wrongly on handle()

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -530,7 +530,7 @@ public:
 
   void update(T new_val) {
     _val = new_val;
-    _empty = static_cast<bool>(new_val);
+    _empty = !(static_cast<bool>(new_val));
   }
 
   operator const dummy *() const {


### PR DESCRIPTION
caused a leak in _demangle_buffer.update(result);