### PR TITLE
Fix rare crash when looking for a function name

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -2831,7 +2831,7 @@ private:
             trace.object_function = demangler.demangle(linkage);
             dwarf_dealloc(dwarf, linkage, DW_DLA_STRING);
           }
-          dwarf_dealloc(dwarf, name, DW_DLA_ATTR);
+          dwarf_dealloc(dwarf, attr_mem, DW_DLA_ATTR);
         }
         break;
 


### PR DESCRIPTION
If we fall back to DWARF processing trying to find a function name we deallocated the wrong object because of a copy/paste error. This part of the code was hit only very rarely, which made this bug undetected for a long time.