### PR TITLE
fix memory leak from demangle

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -530,7 +530,7 @@ public:
 
   void update(T new_val) {
     _val = new_val;
-    _empty = static_cast<bool>(new_val);
+    _empty = !static_cast<bool>(new_val);
   }
 
   operator const dummy *() const {


### PR DESCRIPTION
Fix memory leak that was introduced by a coding mistake
in an earlier attempt to fix a leak on realloc:

  dd8af25 fix a memory leak when __cxa_demangle reallocs

The value of _empty was accidentally negated.

Closes #171