### PR TITLE
Fix compilation error with C++17 compiler

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -35,6 +35,9 @@
 #define BACKWARD_CXX11
 #define BACKWARD_ATLEAST_CXX11
 #define BACKWARD_ATLEAST_CXX98
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define BACKWARD_ATLEAST_CXX17
+#endif
 #else
 #define BACKWARD_CXX98
 #define BACKWARD_ATLEAST_CXX98
@@ -4246,7 +4249,9 @@ public:
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 
     std::set_terminate(&terminator);
+#ifndef BACKWARD_ATLEAST_CXX17
     std::set_unexpected(&terminator);
+#endif
     _set_purecall_handler(&terminator);
     _set_invalid_parameter_handler(&invalid_parameter_handler);
   }


### PR DESCRIPTION
Fixes #198 

My limited testing showed that backward-cpp works fine without the deprecated `std::set_unexpected`. But I cannot guarantee that it would still work for all cases as I was not researching why `std::set_unexpected` was used by backward-cpp and why was it removed from c++17.