### PR TITLE
Add support for Apple Silicon

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -4157,7 +4157,11 @@ public:
 #elif defined(__arm__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)
-    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
+    #if defined(__APPLE__)
+      error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__pc);
+    #elif
+      error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
+    #endif
 #elif defined(__mips__)
     error_addr = reinterpret_cast<void *>(
         reinterpret_cast<struct sigcontext *>(&uctx->uc_mcontext)->sc_pc);


### PR DESCRIPTION
Fixes #200.

When compiling on Apple Silicon at commit `27a8900`, the following build error is produced:
```
In file included from ../backward-cpp/backward.cpp:36:
../backward-cpp/backward.hpp:4160:60: error: member reference type 'struct __darwin_mcontext64 *' is a pointer; did you mean to use '->'?
    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
                                          ~~~~~~~~~~~~~~~~~^
                                                           ->
../backward-cpp/backward.hpp:4160:61: error: no member named 'pc' in '__darwin_mcontext64'
    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
                                          ~~~~~~~~~~~~~~~~~ ^
```
This is caused by [`__aarch64__`](https://github.com/bombela/backward-cpp/blob/27a89004a86fe2a665f041c198c7fbab7489e278/backward.hpp#L4159) being defined on Apple Silicon, however is incorrect for assigning the error address.

A conditional to check for `__APPLE__` was added to the `__aarch64__` #ifdef case with the appropriate error address cast.

All tests pass when compiling for `ARM64` and Universal 2, ran on an M1 Mac (both `ARM64` and Universal 2 binaries) and an Intel Mac.