### PR TITLE
Remove ::resolve override added in #162

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -3616,7 +3616,7 @@ public:
 
   DWORD64 displacement;
 
-  ResolvedTrace resolve(ResolvedTrace t) override {
+  ResolvedTrace resolve(ResolvedTrace t) {
     HANDLE process = GetCurrentProcess();
 
     char name[256];


### PR DESCRIPTION
This fixes https://github.com/bombela/backward-cpp/issues/208 by removing the recently added override.