### PR TITLE
Fix unushed parameter warnings

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1209,7 +1209,10 @@ class StackTrace : public StackTraceImpl<system_tag::current_tag> {};
 
 class TraceResolverImplBase {
 public:
-  virtual void load_addresses(void *const*addresses, int address_count) {}
+  virtual void load_addresses(void *const*addresses, int address_count) {
+    (void)addresses;
+    (void)address_count;
+  }
 
   template <class ST> void load_stacktrace(ST &st) {
     load_addresses(st.begin(), (int)st.size());


### PR DESCRIPTION
Fixes:

```
In file included from 
backward-cpp/backward.hpp: In member function ‘virtual void backward::TraceResolverImplBase::load_addresses(void* const*, int)’:
bombela/backward-cpp/backward.hpp:1214:43: warning: unused parameter ‘addresses’ [-Wunused-parameter]
 1214 |   virtual void load_addresses(void *const*addresses, int address_count) {
      |                               ~~~~~~~~~~~~^~~~~~~~~
bombela/backward-cpp/backward.hpp:1214:58: warning: unused parameter ‘address_count’ [-Wunused-parameter]
 1214 |   virtual void load_addresses(void *const*addresses, int address_count) {
      |                                                      ~~~~^~~~~~~~~~~~~
```