### PR TITLE
Add empty virtual destructor to TraceResolverImplBase base class

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1209,6 +1209,8 @@ class StackTrace : public StackTraceImpl<system_tag::current_tag> {};
 
 class TraceResolverImplBase {
 public:
+  virtual ~TraceResolverImplBase() {}
+
   virtual void load_addresses(void *const*addresses, int address_count) {
     (void)addresses;
     (void)address_count;


### PR DESCRIPTION
Fixes some warnings:

```
... bombela/backward-cpp/backward.hpp:1210:7: warning: ‘class backward::TraceResolverImplBase’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
 1210 | class TraceResolverImplBase {
      |       ^~~~~~~~~~~~~~~~~~~~~
... bombela/backward-cpp/backward.hpp:1243:7: warning: base class ‘class backward::TraceResolverImplBase’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
 1243 | class TraceResolverLinuxBase : public TraceResolverImplBase {
      |       ^~~~~~~~~~~~~~~~~~~~~~
```

I considered using a `= default` virtual destructor, but I wasn't sure about backwards compatibility.