### PR TITLE
Fix compilation under Windows with Visual Studio 14 2015 Win64

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -91,6 +91,7 @@
 #include <string>
 #include <vector>
 #include <exception>
+#include <iterator>
 
 #if defined(BACKWARD_SYSTEM_LINUX)
 


### PR DESCRIPTION
This PR fixes compilation under Windows with Visual Studio 14 2015 Win64.
std::back_inserter() method replaces in <iterator> header file https://en.cppreference.com/w/cpp/iterator/back_inserter.
To fix it, the header file is included.