### PR TITLE
Fix unrecognized flags and barrage of warnings with clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 project(backward CXX)
 
 # Introduce variables:
@@ -44,6 +44,12 @@ if (DEFINED ENV{OMPI_CXX} OR DEFINED ENV{MPICH_CXX})
    endif()
 endif()
 
+# Check if compiler is clang-cl.
+set(COMPILER_IS_CLANG_CL false)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+  set(COMPILER_IS_CLANG_CL true)
+endif()
+
 # set CXX standard
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_STANDARD 11)
@@ -57,11 +63,16 @@ endif()
 ###############################################################################
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-	if (NOT ${COMPILER_IS_NVCC})
-	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+	if (${COMPILER_IS_CLANG_CL})
+	  # clang-cl either needs MSVC options or options passed through with "/clang:<arg>".
+	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /clang:-Wall /clang:-Wextra /clang:-pedantic-errors /clang:-g")
+	else()
+	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+	  if (NOT ${COMPILER_IS_NVCC})
+	    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+	  endif()
+	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 	endif()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 endif()
 
 ###############################################################################


### PR DESCRIPTION
clang-cl needs special handling for non-MSVC options. Also bumping CMake version to 3.1 to avoid CMP0054 OLD behavior.
"-Wall" causes the MSVC-compatible driver to do the equivalent of "-Weverything." "-g" was entirely unrecognized.