### PR TITLE
Don't pass buffer as format string and free buffer

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -3637,13 +3637,14 @@ public:
       char* lpMsgBuf;
       DWORD dw = GetLastError();
 
-      FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                        FORMAT_MESSAGE_FROM_SYSTEM |
-                        FORMAT_MESSAGE_IGNORE_INSERTS,
-                    NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                    (char*)&lpMsgBuf, 0, NULL);
-
-      printf(lpMsgBuf);
+      if (!FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                              FORMAT_MESSAGE_FROM_SYSTEM |
+                              FORMAT_MESSAGE_IGNORE_INSERTS,
+                          NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                          (char*)&lpMsgBuf, 0, NULL)) {
+      std::fprintf(stderr, "%s\n", lpMsgBuf);
+      LocalFree(lpMsgBuf);
+    }
 
       // abort();
     }

--- a/backward.hpp
+++ b/backward.hpp
@@ -3642,9 +3642,9 @@ public:
                              FORMAT_MESSAGE_IGNORE_INSERTS,
                          NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                          (char*)&lpMsgBuf, 0, NULL)) {
-      std::fprintf(stderr, "%s\n", lpMsgBuf);
-      LocalFree(lpMsgBuf);
-    }
+        std::fprintf(stderr, "%s\n", lpMsgBuf);
+        LocalFree(lpMsgBuf);
+      }
 
       // abort();
     }

--- a/backward.hpp
+++ b/backward.hpp
@@ -3637,11 +3637,11 @@ public:
       char* lpMsgBuf;
       DWORD dw = GetLastError();
 
-      if (!FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                              FORMAT_MESSAGE_FROM_SYSTEM |
-                              FORMAT_MESSAGE_IGNORE_INSERTS,
-                          NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                          (char*)&lpMsgBuf, 0, NULL)) {
+      if (FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                             FORMAT_MESSAGE_FROM_SYSTEM |
+                             FORMAT_MESSAGE_IGNORE_INSERTS,
+                         NULL, dw, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                         (char*)&lpMsgBuf, 0, NULL)) {
       std::fprintf(stderr, "%s\n", lpMsgBuf);
       LocalFree(lpMsgBuf);
     }


### PR DESCRIPTION
Fixes warning "format string is not a string literal (potentially insecure)" and a memory leak.