### PR TITLE
fix typo in variable name

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1089,7 +1089,7 @@ public:
 
   size_t load_from(void *addr, size_t depth = 32, void *context = nullptr,
                    void *error_addr = nullptr) {
-    load_here(depth + 8, contxt, error_addr);
+    load_here(depth + 8, context, error_addr);
 
     for (size_t i = 0; i < _stacktrace.size(); ++i) {
       if (_stacktrace[i] == addr) {


### PR DESCRIPTION
It fails to compile on linux when BACKWARD_HAS_BACKTRACE is set because variable name in load_from function has a typo.