### PR TITLE
CMake: prevent leaking of CXX_STANDARD and allow linking as regular library from add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,14 +44,6 @@ if (DEFINED ENV{OMPI_CXX} OR DEFINED ENV{MPICH_CXX})
    endif()
 endif()
 
-# set CXX standard
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_STANDARD 11)
-if (${COMPILER_IS_NVCC})
-  # GNU CXX extensions are not supported by nvcc
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
 ###############################################################################
 # COMPILER FLAGS
 ###############################################################################
@@ -71,6 +63,16 @@ endif()
 add_library(backward_object OBJECT backward.cpp)
 target_compile_definitions(backward_object PRIVATE ${BACKWARD_DEFINITIONS})
 target_include_directories(backward_object PRIVATE ${BACKWARD_INCLUDE_DIRS})
+if(BACKWARD_HAS_EXTERNAL_LIBRARIES)
+  target_link_libraries(backward_object PUBLIC ${BACKWARD_LIBRARIES})
+endif()
+# set CXX standard
+set_property(TARGET backward_object PROPERTY CXX_STANDARD_REQUIRED True)
+set_property(TARGET backward_object PROPERTY CXX_STANDARD 11)
+if (${COMPILER_IS_NVCC})
+  # GNU CXX extensions are not supported by nvcc
+  set_property(TARGET backward_object PROPERTY CXX_EXTENSIONS OFF)
+endif()
 set(BACKWARD_ENABLE $<TARGET_OBJECTS:backward_object> CACHE STRING
 	"Link with this object to setup backward automatically")
 
@@ -86,6 +88,18 @@ endif()
 add_library(backward ${libtype} backward.cpp)
 target_compile_definitions(backward PUBLIC ${BACKWARD_DEFINITIONS})
 target_include_directories(backward PUBLIC ${BACKWARD_INCLUDE_DIRS})
+if(BACKWARD_HAS_EXTERNAL_LIBRARIES)
+  target_link_libraries(backward PUBLIC ${BACKWARD_LIBRARIES})
+endif()
+# set CXX standard
+set_property(TARGET backward PROPERTY CXX_STANDARD_REQUIRED True)
+set_property(TARGET backward PROPERTY CXX_STANDARD 11)
+if (${COMPILER_IS_NVCC})
+  # GNU CXX extensions are not supported by nvcc
+  set_property(TARGET backward PROPERTY CXX_EXTENSIONS OFF)
+endif()
+
+add_library(Backward::Backward ALIAS backward)
 
 ###############################################################################
 # TESTS

--- a/README.md
+++ b/README.md
@@ -57,12 +57,9 @@ In this case you have a subdirectory containing the whole repository of Backward
 ```
 add_subdirectory(/path/to/backward-cpp)
 
-# This will add backward.cpp to your target
-add_executable(mytarget mysource.cpp ${BACKWARD_ENABLE})
-
 # This will add libraries, definitions and include directories needed by backward
-# by setting each property on the target.
-add_backward(mytarget)
+# through an ALIAS target.
+target_link_libraries(mytarget PUBLIC Backward::Backward)
 ```
 
 #### Modifying CMAKE_MODULE_PATH


### PR DESCRIPTION
Currently, the CMake script sets the `CMAKE_CXX_STANDARD` variable to `11`. This leaks into parent projects when adding backward-cpp with `add_subdirectory()`. I have therefore modified the CMake script to explicitly set this property on each target of backward (I am not sure what is the difference between `backward-object` and `backward`, so I did it for both).

Furthermore, the documentation recommends using the `add_backward()` macro to use backward when adding it as a sub-directory. As far as I know, CMake best practices are that you should be able to link to a library in a unique and consistent way, regardless of where it came from (imported, or added as a sub-directory). I have therefore made modifications to the `backward` and `backward-object` targets to include the necessary library dependencies, and defined the alias target `Backward::Backward` to allow linking as with the `find_package()` way, without having to add backward.cpp to the current target:

```cmake
target_link_libraries(my_app PRIVATE Backward::Backward)
```

This PR also updates the README accordingly.