### PR TITLE
Fix tests on aarch64 and mips architecture

### DIFF
--- a/test/suicide.cpp
+++ b/test/suicide.cpp
@@ -58,7 +58,7 @@ void abort_abort_I_repeat_abort_abort() {
 TEST_ABORT(calling_abort) { abort_abort_I_repeat_abort_abort(); }
 
 // aarch64 and mips does not trap Division by zero
-#if !defined(__aarch64__) || !defined(__mips__)
+#if !defined(__aarch64__) && !defined(__mips__)
 volatile int zero = 0;
 
 int divide_by_zero() {


### PR DESCRIPTION
The divide_by_zero is meant to run if both `__aarch64__` and `__mips__` are not defined, meaning that the test is being compiled on any other architecture. As it is now, the test is being compiled also on `__aarch64__` architecture, as `!defined(__mips__)` is true.