### PR TITLE
Allow adding backward as system headers

### DIFF
--- a/BackwardConfig.cmake
+++ b/BackwardConfig.cmake
@@ -79,7 +79,7 @@ if (STACK_WALKING_LIBUNWIND)
 
 	# Disable other unwinders if libunwind is found
 	set(STACK_WALKING_UNWIND FALSE)
-	set(STACK_WALKING_BACKTRACE FALSE)	
+	set(STACK_WALKING_BACKTRACE FALSE)
 endif()
 
 if (${STACK_DETAILS_AUTO_DETECT})
@@ -212,8 +212,13 @@ find_package_handle_standard_args(Backward
 )
 list(APPEND _BACKWARD_INCLUDE_DIRS ${BACKWARD_INCLUDE_DIR})
 
+# add_backward, optional bool argument; if passed and true, backward will be included as a system header
 macro(add_backward target)
-	target_include_directories(${target} PRIVATE ${BACKWARD_INCLUDE_DIRS})
+	if ("${ARGN}")
+		target_include_directories(${target} SYSTEM PRIVATE ${BACKWARD_INCLUDE_DIRS})
+	else()
+		target_include_directories(${target} PRIVATE ${BACKWARD_INCLUDE_DIRS})
+	endif()
 	set_property(TARGET ${target} APPEND PROPERTY COMPILE_DEFINITIONS ${BACKWARD_DEFINITIONS})
 	set_property(TARGET ${target} APPEND PROPERTY LINK_LIBRARIES ${BACKWARD_LIBRARIES})
 endmacro()
@@ -241,7 +246,7 @@ if (NOT TARGET Backward::Backward)
 	)
 	if(BACKWARD_HAS_EXTERNAL_LIBRARIES)
 		set_target_properties(Backward::Backward PROPERTIES
-			INTERFACE_LINK_LIBRARIES "${BACKWARD_LIBRARIES}" 
+			INTERFACE_LINK_LIBRARIES "${BACKWARD_LIBRARIES}"
 		)
 	endif()
 endif()


### PR DESCRIPTION
I can change this as desired, if you want the original function to stay the same I can make a second `add_backward_as_system` function or something else; I did it this was to prevent code duplication going forward but I can edit this if you want something different.

The benefit of allowing include as system is that it allows gcc to ignore warnings generated from this code. For example, if compiling with `-Wall`, you get `W-sign-compare`, as shown [here](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html). Thus, compiling with `-Wall -Werror` may lead to a failure to compile since there are a few sign switches in this code, such as [here](https://github.com/bombela/backward-cpp/blob/4b8715b9081251947e3881098f65f8fa74c300aa/backward.hpp#L1957). By including as a system error, warnings such as this are not emitted and thus never become errors.

In other words, this PR allows people to compile their code with `-Werror` and whichever warning flags they desire without having to worry about how those flags might interact with `backend.hpp`.