### PR TITLE
Allow adding to the file prefix list taken from the env

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -3799,6 +3799,7 @@ public:
 
   // Allow adding to paths gotten from BACKWARD_CXX_SOURCE_PREFIXES after loading the
   // library; this can be useful when the library is loaded when the locations are unknown
+  // Warning: Because this edits the static paths variable, it is *not* intrinsiclly thread safe
   static void add_paths_to_env_variable_impl(const std::string & to_add) {
     get_mutable_paths_from_env_variable().push_back(to_add);
   }
@@ -3817,7 +3818,7 @@ private:
   }
 
   static std::vector<std::string> &get_mutable_paths_from_env_variable() {
-    static std::vector<std::string> paths = get_paths_from_env_variable_impl();
+    static volatile std::vector<std::string> paths = get_paths_from_env_variable_impl();
     return paths;
   }
 

--- a/backward.hpp
+++ b/backward.hpp
@@ -3797,11 +3797,17 @@ public:
   }
 #endif
 
+  // Allow adding to paths gotten from BACKWARD_CXX_SOURCE_PREFIXES after loading the
+  // library; this can be useful when the library is loaded when the locations are unknown
+  static void add_paths_to_env_variable_impl(const std::string & to_add) {
+    get_mutable_paths_from_env_variable().push_back(to_add);
+  }
+
 private:
   details::handle<std::ifstream *, details::default_delete<std::ifstream *>>
       _file;
 
-  std::vector<std::string> get_paths_from_env_variable_impl() {
+  static std::vector<std::string> get_paths_from_env_variable_impl() {
     std::vector<std::string> paths;
     const char *prefixes_str = std::getenv("BACKWARD_CXX_SOURCE_PREFIXES");
     if (prefixes_str && prefixes_str[0]) {
@@ -3810,9 +3816,13 @@ private:
     return paths;
   }
 
-  const std::vector<std::string> &get_paths_from_env_variable() {
+  static std::vector<std::string> &get_mutable_paths_from_env_variable() {
     static std::vector<std::string> paths = get_paths_from_env_variable_impl();
     return paths;
+  }
+
+  static const std::vector<std::string> &get_paths_from_env_variable() {
+    return get_mutable_paths_from_env_variable();
   }
 
 #ifdef BACKWARD_ATLEAST_CXX11

--- a/backward.hpp
+++ b/backward.hpp
@@ -3819,7 +3819,7 @@ private:
 
   static std::vector<std::string> &get_mutable_paths_from_env_variable() {
     static volatile std::vector<std::string> paths = get_paths_from_env_variable_impl();
-    return paths;
+    return const_cast<std::vector<std::string>&>(paths);
   }
 
   static const std::vector<std::string> &get_paths_from_env_variable() {


### PR DESCRIPTION
This can be useful when the library loads before the file paths are known.

For example, if this is being used in a library and the path information is only known by the parent process; without this the library would (by default) before main, before the main process could give this information.

In my use case, this is part of a native module to another programming language, the module is loaded when the native program loads, however, so the program does not have any time to inform backward of where the files.