### PR TITLE
Fix Linux powerpc use of struct pt_regs

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -211,6 +211,12 @@
 #else
 #include <link.h>
 #endif
+#if defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) ||        \
+    defined(__POWERPC__)
+// Linux kernel header required for the struct pt_regs definition
+// to access the NIP (Next Instruction Pointer) register value
+#include <asm/ptrace.h>
+#endif
 #include <signal.h>
 #include <sys/stat.h>
 #include <syscall.h>


### PR DESCRIPTION
Requires using the Linux kernel header file ptrace.h.
Allows struct pt_regs to be used for accessing the
nip (Next Instruction Pointer) register value.

This fixes a compilation problem at https://github.com/bombela/backward-cpp/blob/872350775655ad610f66aea325c319950daa7c95/backward.hpp#L4225 on Alpine Linux.