### PR TITLE
Add note on Clang -gdwarf-aranges option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ what I know).
 If you are missing debug information, the stack trace will lack details about
 your sources.
 
+When using clang++ with libdw, it may be necessary to compile with
+`-gdwarf-aranges` to make source locations visible. Libdw prefers to use a
+`.debug_aranges` section for source location information, which clang++ doesn't
+emit by default.
+
 ### Libraries to read the debug info
 
 Backward supports pretty printed stack traces on GNU/Linux, macOS and Windows,


### PR DESCRIPTION
I encountered a problem when using libdw with Clang 13 on Linux, where backward was not printing source location information for code compiled with Clang (it was visible for gcc-compiled libraries, however). I saw the comment on [line 1845](https://github.com/bombela/backward-cpp/blob/49243890982c7c8de7aaa3887765f6523c2e10dd/backward.hpp#L1845) about Clang not emitting a `.debug_aranges` section and having to use a fallback method to try to find source locations, and found that Clang has a [-gdwarf-aranges](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-gdwarf-aranges) option. Enabling this fixed the problem.

I'm almost positive I had this working in the past, so it's possible that an update to Clang, libdw, or backward broke something here. It worked using gcc, as well as Clang with libbfd.

I may be missing a better way to solve this, but it's probably worth documenting whatever the best answer is.