### PR TITLE
Fix compilation on mingw 32bits

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -344,7 +344,12 @@
 #include <thread>
 
 #include <basetsd.h>
+
+#ifdef _WIN64
 typedef SSIZE_T ssize_t;
+#else
+typedef int ssize_t;
+#endif
 
 #ifndef NOMINMAX
 #define NOMINMAX


### PR DESCRIPTION
Compilation on MinGW 32bits is Failing with

```
[ 66%] Building CXX object CMakeFiles/backward.dir/backward.cpp.obj
In file included from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.cpp:36:
C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.hpp:341:17: error: conflicting declaration 'typedef SSIZE_T ssize_t'
  341 | typedef SSIZE_T ssize_t;
      |                 ^~~~~~~
In file included from D:/a/_temp/msys64/mingw32/include/stdlib.h:9,
                 from D:/a/_temp/msys64/mingw32/include/c++/11.3.0/cstdlib:75,
                 from D:/a/_temp/msys64/mingw32/include/c++/11.3.0/bits/stl_algo.h:59,
                 from D:/a/_temp/msys64/mingw32/include/c++/11.3.0/algorithm:62,
                 from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.hpp:79,
                 from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.cpp:36:
D:/a/_temp/msys64/mingw32/include/corecrt.h:47:13: note: previous declaration as 'typedef int ssize_t'
   47 | typedef int ssize_t;
      |             ^~~~~~~
In file included from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.cpp:36:
C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.hpp:341:17: error: conflicting declaration 'typedef SSIZE_T ssize_t'
  341 | typedef SSIZE_T ssize_t;
      |                 ^~~~~~~
In file included from D:/a/_temp/msys64/mingw32/include/stdlib.h:9,
                 from D:/a/_temp/msys64/mingw32/include/c++/11.3.0/cstdlib:75,
                 from D:/a/_temp/msys64/mingw32/include/c++/11.3.0/bits/stl_algo.h:59,
                 from D:/a/_temp/msys64/mingw32/include/c++/11.3.0/algorithm:62,
                 from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.hpp:79,
                 from C:/Users/runneradmin/AppData/Local/.xmake/cache/packages/2205/b/backward-cpp/v1.6/source/backward.cpp:36:
D:/a/_temp/msys64/mingw32/include/corecrt.h:47:13: note: previous declaration as 'typedef int ssize_t'
   47 | typedef int ssize_t;
      |             ^~~~~~~
make[2]: *** [CMakeFiles/backward.dir/build.make:77: CMakeFiles/backward.dir/backward.cpp.obj] Error 1
make[2]: *** [CMakeFiles/backward_object.dir/build.make:77: CMakeFiles/backward_object.dir/backward.cpp.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:111: CMakeFiles/backward.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/backward_object.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

this pull request fix this issue