### PR TITLE
Explicitly cast `line` and `col` variabiles to `unsigned`.

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1917,8 +1917,8 @@ public:
       int line = 0, col = 0;
       dwarf_lineno(srcloc, &line);
       dwarf_linecol(srcloc, &col);
-      trace.source.line = line;
-      trace.source.col = col;
+      trace.source.line = static_cast<unsigned>(line);
+      trace.source.col = static_cast<unsigned>(col);
     }
 
     deep_first_search_by_pc(cudie, trace_addr - mod_bias,


### PR DESCRIPTION
Explicitly cast `line` and `col` variabiles to `unsigned` to avoid `-Wsign-conversion` (warnings or errors if `-Werror` is enabled).
This avoids unnecessary wrapper header files around `backward.hpp` to ignore this type of warnings or disable the warning everywhere which could be unsafe in some cases.