### PR TITLE
don't crash when `_Unwind_Backtrace` fails

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -810,7 +810,12 @@ public:
     _index = -1;
     _depth = depth;
     _Unwind_Backtrace(&this->backtrace_trampoline, this);
-    return static_cast<size_t>(_index);
+    if (_index == -1) {
+      // _Unwind_Backtrace has failed to obtain any backtraces
+      return 0;
+    } else {
+      return static_cast<size_t>(_index);
+    }
   }
 
 private:
@@ -3614,11 +3619,11 @@ public:
     symOptions |= SYMOPT_LOAD_LINES | SYMOPT_UNDNAME;
     SymSetOptions(symOptions);
     EnumProcessModules(process, &module_handles[0],
-                       static_cast<DWORD>(module_handles.size() * sizeof(HMODULE)), 
+                       static_cast<DWORD>(module_handles.size() * sizeof(HMODULE)),
 		       &cbNeeded);
     module_handles.resize(cbNeeded / sizeof(HMODULE));
     EnumProcessModules(process, &module_handles[0],
-                       static_cast<DWORD>(module_handles.size() * sizeof(HMODULE)), 
+                       static_cast<DWORD>(module_handles.size() * sizeof(HMODULE)),
 		       &cbNeeded);
     std::transform(module_handles.begin(), module_handles.end(),
                    std::back_inserter(modules), get_mod_info(process));


### PR DESCRIPTION
In release build without symbols and frame pointers, `_Unwind_Backtrace` can be a no-op, not invoking the callback even a single time.

This then keeps the `_index` at `-1`, so after casting into `size_t` and attempting to allocate vector with that size, app crashes (vector::resize to MAX_UINT does not work 😛 ).

The issue didn't happen when using the `backtrace` backends - it correctly returns the empty stack trace in that case.

This patch ensures the same behavior also when using `unwind`.