### PR TITLE
Fix tests on PowerPC and RISC-V

### DIFF
--- a/test/suicide.cpp
+++ b/test/suicide.cpp
@@ -57,8 +57,8 @@ void abort_abort_I_repeat_abort_abort() {
 
 TEST_ABORT(calling_abort) { abort_abort_I_repeat_abort_abort(); }
 
-// aarch64 and mips does not trap Division by zero
-#if !defined(__aarch64__) && !defined(__mips__)
+// aarch64, mips, PowerPC and RISC-V do not trap Division by zero
+#if !defined(__aarch64__) && !defined(__mips__) && !defined (__powerpc__) && !defined (__riscv)
 volatile int zero = 0;
 
 int divide_by_zero() {


### PR DESCRIPTION
Both architectures do not trap on division by zero
