### PR TITLE
Support Unknown System build with `BACKWARD_SYSTEM_UNKNOWN=1` in user take stack trace case.

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -727,6 +727,7 @@ public:
   }
   size_t thread_id() const { return 0; }
   void skip_n_firsts(size_t) {}
+  void *const *begin() const { return nullptr; }
 };
 
 class StackTraceImplBase {


### PR DESCRIPTION
In fact, I was build with NDK r21e, which didn't provide `execinfo.h`.

So I set `BACKWARD_SYSTEM_UNKNOWN=1` to build.

I use backward-cpp to tack stacktrace, compiler complain

```
backward.hpp:1236:23: error: no member named 'begin' in 'backward::StackTrace'
    load_addresses(st.begin(), static_cast<int>(st.size()));
backward.hpp:4056:15: note: in instantiation of function template specialization 'backward::TraceResolverImplBase::load_stackt
race<backward::StackTrace>' requested here
    _resolver.load_stacktrace(st);
backward.hpp:4017:5: note: in instantiation of function template specialization 'backward::Printer::print_stacktrace<backward:
:StackTrace>' requested here
    print_stacktrace(st, os, colorize);
```

So I add this api into `StackTraceImpl`