### PR TITLE
Add `sframe` to libbfd's dependencies list

### DIFF
--- a/BackwardConfig.cmake
+++ b/BackwardConfig.cmake
@@ -152,6 +152,11 @@ if (${STACK_DETAILS_AUTO_DETECT})
 		# If we attempt to link against static bfd, make sure to link its dependencies, too
 		get_filename_component(bfd_lib_ext "${LIBBFD_LIBRARY}" EXT)
 		if (bfd_lib_ext STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+			find_library(LIBSFRAME_LIBRARY NAMES sframe)
+			if (LIBSFRAME_LIBRARY)
+				list(APPEND _BACKWARD_LIBRARIES ${LIBSFRAME_LIBRARY})
+			endif()
+
 			list(APPEND _BACKWARD_LIBRARIES iberty z)
 		endif()
 


### PR DESCRIPTION
To bring some context, I tried to build `backward-cpp` for [SerenityOS](https://github.com/SerenityOS/serenity).

We only rely on binutils' Makefile which doesn't generate a `.so` for `libbfd`. When building `backward-cpp` with this configuration, I faced linker errors with symbols from `sframe`. It appears that `sframe` is also a dependency of `libbfd`.

FWIW, it's in phase with what [Arch](https://github.com/archlinux/svntogit-packages/blob/1f454232f6f0d227dd5b4b1eee6b7fc2b4a42fd4/trunk/PKGBUILD#L115) do to package `libbfd.so`:
"echo 'INPUT( /usr/lib/libbfd.a -lsframe -liberty -lz -lzstd -ldl )' > "$pkgdir/usr/lib/libbfd.so""