### PR TITLE
Fix typo in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,8 @@ struct ResolvedTrace: public Trace {
 	struct SourceLoc {
 		std::string function;
 		std::string filename;
-		size_t      line;
-		size_t      col;
+		unsigned    line;
+		unsigned    col;
 	};
 
 	// In which binary object this trace is located.


### PR DESCRIPTION
ResolvedTrace::SourceLoc::line has type 'unsigned', not 'size_t'. Same with ...::col. Fix the documentation to match the production code.