### PR TITLE
Add warning about `backward::SignalHandling`

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,9 @@ this object doesn't do anything. It exposes only one method:
 bool loaded() const // true if loaded with success
 ```
 
+**Warning:** The registered signal handlers are not signal safe and problems can
+arise from using this.
+
 ### Trace object
 
 To keep the memory footprint of a loaded `StackTrace` on the low-side, there a


### PR DESCRIPTION
This PR adds a warning to signal that the `SignalHandling` signal handlers are not signal-safe. The intent of this PR is to warn users about problems described in #74.

There is probably room to improve on the wording, e.g. stating that the goal of `backward::SignalHandling` is to provide basic support for tracing from signals in most cases.