### PR TITLE
Make line format compatible with compilers and editors

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -4148,8 +4148,8 @@ private:
   void print_source_loc(std::ostream &os, const char *indent,
                         const ResolvedTrace::SourceLoc &source_loc,
                         void *addr = nullptr) {
-    os << indent << "Source \"" << source_loc.filename << "\", line "
-       << source_loc.line << ", in " << source_loc.function;
+    os << indent << "Source \"" << source_loc.filename << ":" << source_loc.line 
+       << "\", in " << source_loc.function;
 
     if (address && addr != nullptr) {
       os << " [" << addr << "]";


### PR DESCRIPTION
See issue #315 .

For example, this allows quick navigation in VIM with the `gF` key when hovering over a code location in a stack trace.