### PR TITLE
Pass MSVC exception through SetUnhandledExceptionFilter

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -4333,8 +4333,7 @@ public:
           }
           cv().notify_one();
         }) {
-    SetUnhandledExceptionFilter(crash_handler);
-
+    *prev_exception_filter_ptr() = SetUnhandledExceptionFilter(crash_handler);
     signal(SIGABRT, signal_handler);
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 
@@ -4362,6 +4361,11 @@ private:
   static CONTEXT *ctx() {
     static CONTEXT data;
     return &data;
+  }
+
+  static LPTOP_LEVEL_EXCEPTION_FILTER *prev_exception_filter_ptr() {
+    static LPTOP_LEVEL_EXCEPTION_FILTER prev_exception_filter;
+    return &prev_exception_filter;
   }
 
   enum class crash_status { running, crashed, normal_exit, ending };
@@ -4427,6 +4431,11 @@ private:
   }
 
   NOINLINE static LONG WINAPI crash_handler(EXCEPTION_POINTERS *info) {
+    // Pass-through MSVC exceptions
+    if ((*prev_exception_filter_ptr()) != nullptr &&
+        info->ExceptionRecord->ExceptionCode == 0xE06D7363) {
+      return (*prev_exception_filter_ptr())(info);
+    }
     // The exception info supplies a trace from exactly where the issue was,
     // no need to skip records
     crash_handler(0, info->ContextRecord);


### PR DESCRIPTION
This restores ability to chain std::set_terminate handlers on Windows by passing MSVC C++ runtime exceptions using their `0xE06D7363` system code back to original handler that will later call backward-cpp's terminator.

Without this other `std::set_terminate` handlers were blocked when using backward-cpp.

Accompanying example below. Running `test.exe ex` shows that custom termination handler is now effective and rethrowing prints proper stack trace.
~~~c++
#include <cstring>
#include <stdexcept>
#include "backward.hpp"

backward::SignalHandling sh;

void crash(const char* mode) {
  if (!std::strcmp(mode, "ex")) {
    throw std::runtime_error("std exception test");
  }
  if (!std::strcmp(mode, "strex")) {
    throw "string exception test";
  }
  int* n = nullptr;
  *n = 1;
}

void pass2(const char* mode) { crash(mode); }

void pass1(const char* mode) { pass2(mode); }

int main(int argc, char const *argv[]) {
  std::set_terminate([]() {
    const std::exception_ptr ex = std::current_exception();
    try {
        std::rethrow_exception(ex);
    } catch (std::exception ex) {
        std::cerr << "Uncaught exception: " << ex.what() << std::endl;
    }
  });
  const char* mode = argc == 2 ? argv[1] : "crash";
  std::cerr << "mode: " << mode << std::endl;
  pass1(mode);
}
~~~