### PR TITLE
Adding new load_saved function

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -740,6 +740,9 @@ public:
   void skip_n_firsts(size_t n) { _skip = n; }
 
 protected:
+  void load_saved(void** arr, size_t sz, std::vector<void*>& v) {
+    copy(&arr[0], &arr[sz], back_inserter(v));
+  }
   void load_thread_info() {
 #ifdef BACKWARD_SYSTEM_LINUX
 #ifndef __ANDROID__
@@ -880,6 +883,9 @@ public:
     _stacktrace.resize(trace_cnt);
     skip_n_firsts(0);
     return size();
+  }
+  void load_saved(void** arr, size_t sz) {
+    StackTraceImplBase::load_saved(arr, sz, _stacktrace);
   }
   size_t load_from(void *addr, size_t depth = 32, void *context = nullptr,
                    void *error_addr = nullptr) {
@@ -1065,6 +1071,10 @@ public:
     return size();
   }
 
+  void load_saved(void** arr, size_t sz) {
+    StackTraceImplBase::load_saved(arr, sz, _stacktrace);
+  }
+
   size_t load_from(void *addr, size_t depth = 32, void *context = nullptr,
                    void *error_addr = nullptr) {
     load_here(depth + 8, context, error_addr);
@@ -1101,6 +1111,10 @@ public:
     _stacktrace.resize(trace_cnt);
     skip_n_firsts(1);
     return size();
+  }
+
+  void load_saved(void** arr, size_t sz) {
+    StackTraceImplBase::load_saved(arr, sz, _stacktrace);
   }
 
   size_t load_from(void *addr, size_t depth = 32, void *context = nullptr,
@@ -1195,6 +1209,10 @@ public:
     }
 
     return size();
+  }
+
+  void load_saved(void** arr, size_t sz) {
+    StackTraceImplBase::load_saved(arr, sz, _stacktrace);
   }
 
   size_t load_from(void *addr, size_t depth = 32, void *context = nullptr,


### PR DESCRIPTION
Adding new `load_saved` function to allow loading a previously obtained stacktrace to be printed.

Currently, there does not appear to be any way to use a stacktrace that might have been obtained earlier (e.g. by `backtrace`).
This is particularly relevant if a signal handler has captured a stacktrace, which might want to be printed at a later time.

Example use:
```
constexpr int max_stackdepth_for_trace = 128;
void *saved_st[max_stackdepth_for_trace];
int SavedStacktraceDepth;

SavedStacktraceDepth = backtrace(saved_st, max_stackdepth_for_trace);

[later]
StackTrace st;
st.load_saved(saved_st, SavedStacktraceDepth);
TraceResolver tr;
tr.load_stacktrace(st);

backward::Printer p;
std::stringstream &ss
p.snippet    = EnableVerboseBackTraces;
p.object     = EnableVerboseBackTraces;
p.address    = true;
p.color_mode = backward::ColorMode::always;

p.print(st, ss);
```