### PR TITLE
add support for loongarch

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -4280,6 +4280,8 @@ public:
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__rip);
 #elif defined(__APPLE__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__eip);
+#elif defined(__loongarch__)
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.__pc);
 #else
 #warning ":/ sorry, ain't know no nothing none not of your architecture!"
 #endif


### PR DESCRIPTION
test pass with gcc on loongarch64:
```
tsingkong@debian:/data/github/backward-cpp$ ./builds.sh test
make: 进入目录“/data/github/backward-cpp/build_c++98_gcc”
Running tests...
Test project /data/github/backward-cpp/build_c++98_gcc
    Start 1: test
1/5 Test #1: test .............................   Passed    0.38 sec
    Start 2: stacktrace
2/5 Test #2: stacktrace .......................   Passed    0.00 sec
    Start 3: rectrace
3/5 Test #3: rectrace .........................   Passed    0.00 sec
    Start 4: select_signals
4/5 Test #4: select_signals ...................   Passed    0.26 sec
    Start 5: suicide
5/5 Test #5: suicide ..........................   Passed    0.81 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   1.47 sec
make: 离开目录“/data/github/backward-cpp/build_c++98_gcc”
make: 进入目录“/data/github/backward-cpp/build_c++11_gcc”
Running tests...
Test project /data/github/backward-cpp/build_c++11_gcc
    Start 1: test
1/5 Test #1: test .............................   Passed    0.28 sec
    Start 2: stacktrace
2/5 Test #2: stacktrace .......................   Passed    0.00 sec
    Start 3: rectrace
3/5 Test #3: rectrace .........................   Passed    0.00 sec
    Start 4: select_signals
4/5 Test #4: select_signals ...................   Passed    0.27 sec
    Start 5: suicide
5/5 Test #5: suicide ..........................   Passed    0.84 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   1.40 sec
make: 离开目录“/data/github/backward-cpp/build_c++11_gcc”
```