### PR TITLE
Explicitly use std::move

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -419,7 +419,6 @@ namespace details {
 template <typename K, typename V> struct hashtable {
   typedef std::unordered_map<K, V> type;
 };
-using std::move;
 } // namespace details
 } // namespace backward
 #else // NOT BACKWARD_ATLEAST_CXX11
@@ -1656,9 +1655,9 @@ private:
       return r; // damned, that's a stripped file that you got there!
     }
 
-    r->handle = move(bfd_handle);
-    r->symtab = move(symtab);
-    r->dynamic_symtab = move(dynamic_symtab);
+    r->handle = std::move(bfd_handle);
+    r->symtab = std::move(symtab);
+    r->dynamic_symtab = std::move(dynamic_symtab);
     return r;
   }
 
@@ -2471,8 +2470,8 @@ private:
         // If we have a valid elf handle, return the new elf handle
         // and file handle and discard the original ones
         if (debuglink_elf) {
-          elf_handle = move(debuglink_elf);
-          file_handle = move(debuglink_file);
+          elf_handle = std::move(debuglink_elf);
+          file_handle = std::move(debuglink_file);
         }
       }
     }
@@ -2494,9 +2493,9 @@ private:
 
     dwarf_handle.reset(dwarf_debug);
 
-    r.file_handle = move(file_handle);
-    r.elf_handle = move(elf_handle);
-    r.dwarf_handle = move(dwarf_handle);
+    r.file_handle = std::move(file_handle);
+    r.elf_handle = std::move(elf_handle);
+    r.dwarf_handle = std::move(dwarf_handle);
 
     return r;
   }


### PR DESCRIPTION
I'm using this library in a project that makes heavy use of linters/clang format etc and not using qualified std::move was causing compilation errors specifically in clang.

I made this change to accommodate for that