### PR TITLE
backward.hpp: fix for macOS PowerPC

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -4269,6 +4269,8 @@ public:
 #elif defined(__mips__)
     error_addr = reinterpret_cast<void *>(
         reinterpret_cast<struct sigcontext *>(&uctx->uc_mcontext)->sc_pc);
+#elif defined(__APPLE__) && defined(__POWERPC__)
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__srr0);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) ||        \
     defined(__POWERPC__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.regs->nip);


### PR DESCRIPTION
This fix covers 10.5–10.6. (For 10.4 `ss.srr0` should be used instead of `__ss.__srr0`, but I assume it is unneeded to complicate the code for that sake.)

P. S. I have been pointed out to the original code from here: https://github.com/d99kris/heapusage/pull/17