### PR TITLE
Use qualified details::move

### DIFF
--- a/backward.hpp
+++ b/backward.hpp
@@ -1668,9 +1668,9 @@ private:
       return r; // damned, that's a stripped file that you got there!
     }
 
-    r->handle = move(bfd_handle);
-    r->symtab = move(symtab);
-    r->dynamic_symtab = move(dynamic_symtab);
+    r->handle = details::move(bfd_handle);
+    r->symtab = details::move(symtab);
+    r->dynamic_symtab = details::move(dynamic_symtab);
     return r;
   }
 
@@ -2483,8 +2483,8 @@ private:
         // If we have a valid elf handle, return the new elf handle
         // and file handle and discard the original ones
         if (debuglink_elf) {
-          elf_handle = move(debuglink_elf);
-          file_handle = move(debuglink_file);
+          elf_handle = details::move(debuglink_elf);
+          file_handle = details::move(debuglink_file);
         }
       }
     }
@@ -2506,9 +2506,9 @@ private:
 
     dwarf_handle.reset(dwarf_debug);
 
-    r.file_handle = move(file_handle);
-    r.elf_handle = move(elf_handle);
-    r.dwarf_handle = move(dwarf_handle);
+    r.file_handle = details::move(file_handle);
+    r.elf_handle = details::move(elf_handle);
+    r.dwarf_handle = details::move(dwarf_handle);
 
     return r;
   }


### PR DESCRIPTION
This PR changes unqualified `move` calls to qualified versions `details::move`.

This avoids a warning `unqualified call to 'std::move'` if an unqualified move resolves to `std::move`.

For more info see `-Wunqualified-std-cast-call` or https://reviews.llvm.org/D119670?id=408276

Example Warning/Error:

```
[...]backward.hpp:2642:34: error: unqualified call to 'std::move' [-Werror,-Wunqualified-std-cast-call]
 2642 |                     elf_handle = move(debuglink_elf);
      |                                  ^
      |                                  std::
```

I think this PR could also replace #349.